### PR TITLE
Bugfix/vote wrapping

### DIFF
--- a/ui/Feed.js
+++ b/ui/Feed.js
@@ -262,6 +262,15 @@ const VOTE_MUTATION = gql`
 
 const FeedWithDataAndMutations = graphql(VOTE_MUTATION, {
   name: 'vote',
+  props({ownProps, vote}) {
+    return {
+      vote({repoFullName, type}) {
+        return vote({
+          variables: { repoFullName, type },
+        })
+      }
+    };
+  },
 })(FeedWithData);
 
 export default FeedWithDataAndMutations;

--- a/ui/Feed.js
+++ b/ui/Feed.js
@@ -262,7 +262,7 @@ const VOTE_MUTATION = gql`
 
 const FeedWithDataAndMutations = graphql(VOTE_MUTATION, {
   name: 'vote',
-  props({ownProps, vote}) {
+  props({vote}) {
     return {
       vote({repoFullName, type}) {
         return vote({


### PR DESCRIPTION
Fixes #78 

I don't completely understand what is going on here so if sombody is able to explain then that would be awesome!

I was able to fix it by comparing it to `commentPage.js` I noticed it had this
```javascript
const CommentsPageWithMutations = graphql(SUBMIT_COMMENT_MUTATION, {
  props({ ownProps, mutate }) {
    return {
      submit({ repoFullName, commentContent }) {
        return mutate({
          variables: { repoFullName, commentContent },
          optimisticResponse: {
            __typename: 'Mutation',
            submitComment: {
              __typename: 'Comment',
              postedBy: ownProps.currentUser,
              createdAt: +new Date,
              content: commentContent,
            },
          },
          updateQueries: {
            Comment: (prev, { mutationResult }) => {
              const newComment = mutationResult.data.submitComment;
              return update(prev, {
                entry: {
                  comments: {
                    $unshift: [newComment],
                  },
                },
              });
            },
          },
        });
      },
    };
  },
})(CommentsPage);
```
by 'this' I mean the props method

but `Feed.js` did not, should vote on line `268` be refactored to be mutate?
